### PR TITLE
Fix Syntax Error when loading the CiviContact Authentication tab on t…

### DIFF
--- a/CRM/Civicontact/Utils/Authentication.php
+++ b/CRM/Civicontact/Utils/Authentication.php
@@ -7,14 +7,14 @@ class CRM_Civicontact_Utils_Authentication {
   /**
    * The prefix for key name in cache table
    */
-  public const HASH_PREFIX = 'CCA-HASH-CID-';
+  const HASH_PREFIX = 'CCA-HASH-CID-';
 
   /**
    * The key name in settings table
    */
-  public const SETTINGS = 'cca_auth';
+  const SETTINGS = 'cca_auth';
 
-  public const ORIGINS
+  const ORIGINS
     = [
       'ionic://localhost',
       'http://localhost'


### PR DESCRIPTION
…he CiviCRM Contact Record

This fixes a syntax error that i discovered when deploying this extension onto a JMA Staging site

ParseError: syntax error, unexpected 'const' (T_CONST), expecting variable (T_VARIABLE) in CRM_Core_ClassLoader->loadClass() (line 8 of ....civicrm/ext/au.com.agileware.civicontactapi/CRM/Civicontact/Utils/Authentication.php).

The PHP version of the server is: 

PHP 7.0.33-0ubuntu0.16.04.7 (cli) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2017 Zend Technologies
    with Zend OPcache v7.0.33-0ubuntu0.16.04.7, Copyright (c) 1999-2017, by Zend Technologies

ping @agileware-justin 