### PR TITLE
Remove duplicate function that causes a fatal error

### DIFF
--- a/api/v3/Relationship/Favourites.php
+++ b/api/v3/Relationship/Favourites.php
@@ -63,25 +63,3 @@ function civicrm_api3_relationship_Favourites($params) {
 
   throw new API_Exception('Favourites not found for ' . $contactID, 404);
 }
-
-
-/**
- * Create favourite relationship type
- *
- * @return Array of relationship type values
- */
-function createFavouriteRelationshipType() {
-  $relationshiptype = civicrm_api3('RelationshipType', 'create', [
-    "name_a_b" => "has favourited",
-    "name_b_a" => "is favourited by",
-    "label_a_b" => "Has Favourited",
-    "label_b_a" => "Is Favourited By",
-    "description" => "Relationship to mark any contact as a favourite of another contact",
-    "contact_type_a" => "Individual",
-    "contact_type_b" => "Individual",
-    "is_active" => 1,
-    "is_reserved" => 0,
-    "sequential" => 1,
-  ]);
-  return $relationshiptype;
-}


### PR DESCRIPTION
When attempting to run an API import this was triggering a fatal error - attempting to redeclare function name.

I think to replicate it's required to 
installing https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/ 
heading to 
civicrm/csvimporter/import

I have not looked at if this now breaks this extension code but it fixes the fatal error and we can now run the import!

There was no submit issue option so did a very quick PR. I assume there will need to be some additional modification if one file is ever loaded without the other.