### PR TITLE
update civicontactapi.civix.php for PHP 7.4 compatibility

### DIFF
--- a/civicontactapi.civix.php
+++ b/civicontactapi.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_Civicontact_ExtensionUtil {
-  const SHORT_NAME = "civicontactapi";
-  const LONG_NAME = "au.com.agileware.civicontactapi";
-  const CLASS_PREFIX = "CRM_Civicontact";
+  const SHORT_NAME = 'civicontactapi';
+  const LONG_NAME = 'au.com.agileware.civicontactapi';
+  const CLASS_PREFIX = 'CRM_Civicontact';
 
   /**
    * Translate a string using the extension's domain.
@@ -24,9 +24,9 @@ class CRM_Civicontact_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = array()) {
+  public static function ts($text, $params = []) {
     if (!array_key_exists('domain', $params)) {
-      $params['domain'] = array(self::LONG_NAME, NULL);
+      $params['domain'] = [self::LONG_NAME, NULL];
     }
     return ts($text, $params);
   }
@@ -100,7 +100,7 @@ function _civicontactapi_civix_civicrm_config(&$config = NULL) {
     array_unshift($template->template_dir, $extDir);
   }
   else {
-    $template->template_dir = array($extDir, $template->template_dir);
+    $template->template_dir = [$extDir, $template->template_dir];
   }
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
@@ -140,7 +140,7 @@ function _civicontactapi_civix_civicrm_install() {
 function _civicontactapi_civix_civicrm_postInstall() {
   _civicontactapi_civix_civicrm_config();
   if ($upgrader = _civicontactapi_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onPostInstall'))) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
       $upgrader->onPostInstall();
     }
   }
@@ -166,7 +166,7 @@ function _civicontactapi_civix_civicrm_uninstall() {
 function _civicontactapi_civix_civicrm_enable() {
   _civicontactapi_civix_civicrm_config();
   if ($upgrader = _civicontactapi_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onEnable'))) {
+    if (is_callable([$upgrader, 'onEnable'])) {
       $upgrader->onEnable();
     }
   }
@@ -181,7 +181,7 @@ function _civicontactapi_civix_civicrm_enable() {
 function _civicontactapi_civix_civicrm_disable() {
   _civicontactapi_civix_civicrm_config();
   if ($upgrader = _civicontactapi_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onDisable'))) {
+    if (is_callable([$upgrader, 'onDisable'])) {
       $upgrader->onDisable();
     }
   }
@@ -193,8 +193,9 @@ function _civicontactapi_civix_civicrm_disable() {
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
@@ -217,43 +218,21 @@ function _civicontactapi_civix_upgrader() {
 }
 
 /**
- * Search directory tree for files which match a glob pattern
+ * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
+ * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
+ * for backward compatibility of extension code that uses it.
  *
- * @param $dir string, base dir
- * @param $pattern string, glob pattern, eg "*.txt"
- * @return array(string)
+ * @param string $dir base dir
+ * @param string $pattern , glob pattern, eg "*.txt"
+ *
+ * @return array
  */
 function _civicontactapi_civix_find_files($dir, $pattern) {
-  if (is_callable(array('CRM_Utils_File', 'findFiles'))) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = array($dir);
-  $result = array();
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_civicontactapi_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
+  return CRM_Utils_File::findFiles($dir, $pattern);
 }
+
 /**
  * (Delegated) Implements hook_civicrm_managed().
  *
@@ -296,14 +275,13 @@ function _civicontactapi_civix_civicrm_caseTypes(&$caseTypes) {
     $name = preg_replace('/\.xml$/', '', basename($file));
     if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
       $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      CRM_Core_Error::fatal($errorMessage);
-      // throw new CRM_Core_Exception($errorMessage);
+      throw new CRM_Core_Exception($errorMessage);
     }
-    $caseTypes[$name] = array(
+    $caseTypes[$name] = [
       'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
-    );
+    ];
   }
 }
 
@@ -361,11 +339,12 @@ function _civicontactapi_civix_civicrm_themes(&$themes) {
  *
  * @link http://php.net/glob
  * @param string $pattern
- * @return array, possibly empty
+ *
+ * @return array
  */
 function _civicontactapi_civix_glob($pattern) {
   $result = glob($pattern);
-  return is_array($result) ? $result : array();
+  return is_array($result) ? $result : [];
 }
 
 /**
@@ -376,16 +355,18 @@ function _civicontactapi_civix_glob($pattern) {
  *    'Mailing', or 'Administer/System Settings'
  * @param array $item - the item to insert (parent/child attributes will be
  *    filled for you)
+ *
+ * @return bool
  */
 function _civicontactapi_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    $menu[] = array(
-      'attributes' => array_merge(array(
+    $menu[] = [
+      'attributes' => array_merge([
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-      ), $item),
-    );
+      ], $item),
+    ];
     return TRUE;
   }
   else {
@@ -396,9 +377,9 @@ function _civicontactapi_civix_insert_navigation_menu(&$menu, $path, $item) {
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
         if (!isset($entry['child'])) {
-          $entry['child'] = array();
+          $entry['child'] = [];
         }
-        $found = _civicontactapi_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        $found = _civicontactapi_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
@@ -409,7 +390,7 @@ function _civicontactapi_civix_insert_navigation_menu(&$menu, $path, $item) {
  * (Delegated) Implements hook_civicrm_navigationMenu().
  */
 function _civicontactapi_civix_navigationMenu(&$nodes) {
-  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
     _civicontactapi_civix_fixNavigationMenu($nodes);
   }
 }
@@ -467,20 +448,17 @@ function _civicontactapi_civix_civicrm_alterSettingsFolders(&$metaDataFolders = 
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
-
 function _civicontactapi_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, array (
-    'CRM_Civicontact_DAO_CCAGroupContactsLog' => 
-    array (
+  $entityTypes = array_merge($entityTypes, [
+    'CRM_Civicontact_DAO_CCAGroupContactsLog' => [
       'name' => 'CCAGroupContactsLog',
       'class' => 'CRM_Civicontact_DAO_CCAGroupContactsLog',
       'table' => 'civicrm_cca_group_contacts_log',
-    ),
-    'CRM_Civicontact_DAO_CCAGroupsLog' => 
-    array (
+    ],
+    'CRM_Civicontact_DAO_CCAGroupsLog' => [
       'name' => 'CCAGroupsLog',
       'class' => 'CRM_Civicontact_DAO_CCAGroupsLog',
       'table' => 'civicrm_cca_groups_log',
-    ),
-  ));
+    ],
+  ]);
 }


### PR DESCRIPTION
Just ran `civix generate:module` to regenerate the `civix.php` file to not throw notices on PHP 7.4.