### PR TITLE
fix creation of favourites relationship type on start

### DIFF
--- a/CRM/Civicontact/Utils/Favourites.php
+++ b/CRM/Civicontact/Utils/Favourites.php
@@ -1,0 +1,26 @@
+<?php
+
+use CRM_Civicontact_ExtensionUtil as E;
+
+class CRM_Civicontact_Utils_Favourites {
+
+  /**
+   * Create favourite relationship type
+   */
+  public static function createFavouriteRelationshipType() : array {
+    $relationshiptype = civicrm_api3('RelationshipType', 'create', [
+      "name_a_b" => "has favourited",
+      "name_b_a" => "is favourited by",
+      "label_a_b" => "Has Favourited",
+      "label_b_a" => "Is Favourited By",
+      "description" => "Relationship to mark any contact as a favourite of another contact",
+      "contact_type_a" => "Individual",
+      "contact_type_b" => "Individual",
+      "is_active" => 1,
+      "is_reserved" => 0,
+      "sequential" => 1,
+    ]);
+    return $relationshiptype;
+  }
+
+}

--- a/api/v3/Relationship/Favourites.php
+++ b/api/v3/Relationship/Favourites.php
@@ -42,7 +42,7 @@ function civicrm_api3_relationship_Favourites($params) {
   ]);
 
   if ($relationshiptype["count"] == 0) {
-    $relationshiptype = createFavouriteRelationshipType();
+    $relationshiptype = CRM_Civicontact_Utils_Favourites::createFavouriteRelationshipType();
   }
   else {
     $relationshiptype = $relationshiptype["values"][0];

--- a/api/v3/Relationship/Markfavourite.php
+++ b/api/v3/Relationship/Markfavourite.php
@@ -46,7 +46,7 @@ function civicrm_api3_relationship_Markfavourite($params) {
   ]);
 
   if ($relationshiptype["count"] == 0) {
-    $relationshiptype = createFavouriteRelationshipType();
+    $relationshiptype = CRM_Civicontact_Utils_Favourites::createFavouriteRelationshipType();
   }
 
   $relationshiptype = $relationshiptype["values"][0];
@@ -69,25 +69,4 @@ function civicrm_api3_relationship_Markfavourite($params) {
   ]);
 
   return $relation;
-}
-
-/**
- * Create favourite relationship type
- *
- * @return Array of relationship type values
- */
-function createFavouriteRelationshipType() {
-  $relationshiptype = civicrm_api3('RelationshipType', 'create', [
-    "name_a_b" => "has favourited",
-    "name_b_a" => "is favourited by",
-    "label_a_b" => "Has Favourited",
-    "label_b_a" => "Is Favourited By",
-    "description" => "Relationship to mark any contact as a favourite of another contact",
-    "contact_type_a" => "Individual",
-    "contact_type_b" => "Individual",
-    "is_active" => 1,
-    "is_reserved" => 0,
-    "sequential" => 1,
-  ]);
-  return $relationshiptype;
 }


### PR DESCRIPTION
PR #4 removed `createFavouriteRelationshipType()` from  api/v3/Relationship/Favourites.php, which fixed the redeclaration of this function, but that API relies on this function being present.  I moved it to a utilities class, which should satisfy both concerns.